### PR TITLE
Added upvote and downvote for media recommendations

### DIFF
--- a/core/domain/src/main/java/com/axiel7/anihyou/core/domain/repository/MediaRepository.kt
+++ b/core/domain/src/main/java/com/axiel7/anihyou/core/domain/repository/MediaRepository.kt
@@ -16,6 +16,7 @@ import com.axiel7.anihyou.core.network.api.MediaApi
 import com.axiel7.anihyou.core.network.type.AiringSort
 import com.axiel7.anihyou.core.network.type.MediaSort
 import com.axiel7.anihyou.core.network.type.MediaType
+import com.axiel7.anihyou.core.network.type.RecommendationRating
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -219,6 +220,16 @@ class MediaRepository (
                 ?.sortedBy { it.nextAiringEpisode?.timeUntilAiring }
                 .orEmpty()
         }
+
+    fun saveRecommendation(
+        mediaId: Int,
+        mediaRecommendationId: Int,
+        rating: RecommendationRating?
+    ) = api.saveRecommendationMutation(
+        mediaId = mediaId,
+        mediaRecommendationId = mediaRecommendationId,
+        rating = rating
+    ).toFlow().asDataResult()
 
     // MyAnimeList endpoints
 

--- a/core/network/src/main/graphql/extra.graphqls
+++ b/core/network/src/main/graphql/extra.graphqls
@@ -16,6 +16,8 @@ extend type ListActivity @typePolicy(keyFields: "id")
 extend type ActivityReply @typePolicy(keyFields: "id")
 extend type Thread @typePolicy(keyFields: "id")
 extend type ThreadComment @typePolicy(keyFields: "id")
+extend type Recommendation @typePolicy(keyFields: "id")
+extend type Review @typePolicy(keyFields: "id")
 
 extend type Query @fieldPolicy(forField: "User", keyArgs: "id")
 extend type Query @fieldPolicy(forField: "Media", keyArgs: "id")

--- a/core/network/src/main/graphql/operations/mediadetails/MediaRelationsAndRecommendations.graphql
+++ b/core/network/src/main/graphql/operations/mediadetails/MediaRelationsAndRecommendations.graphql
@@ -27,7 +27,9 @@ fragment MediaRelated on MediaEdge {
 }
 
 fragment MediaRecommended on Recommendation {
+    id
     rating
+    userRating
     mediaRecommendation {
         ...BasicMediaDetails
         coverImage {

--- a/core/network/src/main/graphql/operations/mediadetails/SaveRecommendation.graphql
+++ b/core/network/src/main/graphql/operations/mediadetails/SaveRecommendation.graphql
@@ -1,0 +1,7 @@
+mutation SaveRecommendation($mediaId: Int, $mediaRecommendationId: Int, $rating: RecommendationRating) {
+    SaveRecommendation(mediaId: $mediaId, mediaRecommendationId: $mediaRecommendationId, rating: $rating) {
+        id
+        rating
+        userRating
+    }
+}

--- a/core/network/src/main/java/com/axiel7/anihyou/core/network/api/MediaApi.kt
+++ b/core/network/src/main/java/com/axiel7/anihyou/core/network/api/MediaApi.kt
@@ -18,6 +18,7 @@ import com.axiel7.anihyou.core.network.MediaReviewsQuery
 import com.axiel7.anihyou.core.network.MediaSortedQuery
 import com.axiel7.anihyou.core.network.MediaStatsQuery
 import com.axiel7.anihyou.core.network.MediaThreadsQuery
+import com.axiel7.anihyou.core.network.SaveRecommendationMutation
 import com.axiel7.anihyou.core.network.SearchMediaQuery
 import com.axiel7.anihyou.core.network.SeasonalAnimeQuery
 import com.axiel7.anihyou.core.network.api.model.AnimeSeasonDto
@@ -29,6 +30,7 @@ import com.axiel7.anihyou.core.network.type.MediaSort
 import com.axiel7.anihyou.core.network.type.MediaSource
 import com.axiel7.anihyou.core.network.type.MediaStatus
 import com.axiel7.anihyou.core.network.type.MediaType
+import com.axiel7.anihyou.core.network.type.RecommendationRating
 import com.axiel7.anihyou.core.network.type.ThreadSort
 
 class MediaApi(
@@ -313,6 +315,18 @@ class MediaApi(
         .query(
             BasicMediaDetailsQuery(
                 mediaId = Optional.present(mediaId)
+            )
+        )
+    fun saveRecommendationMutation(
+        mediaId: Int,
+        mediaRecommendationId: Int,
+        rating: RecommendationRating?
+    ) = client
+        .mutation(
+            SaveRecommendationMutation(
+                mediaId = Optional.present(mediaId),
+                mediaRecommendationId = Optional.present(mediaRecommendationId),
+                rating = Optional.present(rating)
             )
         )
 }

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -645,4 +645,6 @@
     <string name="app_installed_required">No nearby device detected, please install the latest AniHyou app version on your Android phone</string>
     <string name="minimum_tag_percentage">Minimum Tag Percentage</string>
     <string name="search_my_list">Search my list…</string>
+    <string name="upvote">Upvote Media</string>
+    <string name="downvote">Downvote Media</string>
 </resources>

--- a/core/ui/src/main/java/com/axiel7/anihyou/core/ui/composables/TextIcon.kt
+++ b/core/ui/src/main/java/com/axiel7/anihyou/core/ui/composables/TextIcon.kt
@@ -2,12 +2,15 @@ package com.axiel7.anihyou.core.ui.composables
 
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Surface
@@ -148,6 +151,55 @@ fun TextSubtitleVertical(
             textAlign = TextAlign.Center,
             lineHeight = 15.sp
         )
+    }
+}
+
+@Composable
+fun UpvoteDownvoteHorizontalText (
+    ratingText: String,
+    isUpvoted: Boolean,
+    isDownvoted: Boolean,
+    onUpvoteClick: () -> Unit,
+    onDownvoteClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = ratingText,
+            color = MaterialTheme.colorScheme.outline,
+            fontSize = 14.sp
+        )
+        Row(
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(
+                onClick = onUpvoteClick,
+                modifier = Modifier.size(32.dp)
+            ) {
+                Icon(
+                    painter = painterResource(id = if (isUpvoted) R.drawable.thumb_up_filled_24 else R.drawable.thumb_up_24),
+                    contentDescription = stringResource(id = R.string.upvote),
+                    tint = MaterialTheme.colorScheme.outline,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+            IconButton(
+                onClick = onDownvoteClick,
+                modifier = Modifier.size(32.dp)
+            ) {
+                Icon(
+                    painter = painterResource(id = if (isDownvoted) R.drawable.thumb_down_filled_24 else R.drawable.thumb_down_24),
+                    contentDescription = stringResource(id = R.string.downvote),
+                    tint = MaterialTheme.colorScheme.outline,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+        }
     }
 }
 

--- a/core/ui/src/main/java/com/axiel7/anihyou/core/ui/composables/TextIcon.kt
+++ b/core/ui/src/main/java/com/axiel7/anihyou/core/ui/composables/TextIcon.kt
@@ -155,7 +155,7 @@ fun TextSubtitleVertical(
 }
 
 @Composable
-fun UpvoteDownvoteHorizontalText (
+fun UpvoteDownvoteHorizontalText(
     ratingText: String,
     isUpvoted: Boolean,
     isDownvoted: Boolean,

--- a/feature/mediadetails/src/main/java/com/axiel7/anihyou/feature/mediadetails/MediaDetailsEvent.kt
+++ b/feature/mediadetails/src/main/java/com/axiel7/anihyou/feature/mediadetails/MediaDetailsEvent.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Immutable
 import com.axiel7.anihyou.core.base.event.UiEvent
 import com.axiel7.anihyou.core.network.fragment.BasicMediaListEntry
 import com.axiel7.anihyou.core.network.fragment.MediaCharacter
+import com.axiel7.anihyou.core.network.type.RecommendationRating
 
 @Immutable
 interface MediaDetailsEvent : UiEvent {
@@ -17,4 +18,5 @@ interface MediaDetailsEvent : UiEvent {
     fun fetchActivity()
     fun showVoiceActorsSheet(character: MediaCharacter)
     fun hideVoiceActorSheet()
+    fun onVoteClick(recommendedMediaId: Int, recommendationId: Int, rating: RecommendationRating)
 }

--- a/feature/mediadetails/src/main/java/com/axiel7/anihyou/feature/mediadetails/MediaDetailsView.kt
+++ b/feature/mediadetails/src/main/java/com/axiel7/anihyou/feature/mediadetails/MediaDetailsView.kt
@@ -510,7 +510,8 @@ fun MediaInfoTabs(
                 MediaRelationsView(
                     uiState = uiState,
                     fetchData = { event?.fetchRelationsAndRecommendations() },
-                    navigateToDetails = navActionManager::toMediaDetails
+                    navigateToDetails = navActionManager::toMediaDetails,
+                    onVoteClick = { mediaId, recId, rating -> event?.onVoteClick(mediaId, recId, rating) },
                 )
 
             MediaDetailsType.STATS ->

--- a/feature/mediadetails/src/main/java/com/axiel7/anihyou/feature/mediadetails/MediaDetailsViewModel.kt
+++ b/feature/mediadetails/src/main/java/com/axiel7/anihyou/feature/mediadetails/MediaDetailsViewModel.kt
@@ -233,11 +233,11 @@ class MediaDetailsViewModel(
                     val relAndRecs = state.relationsAndRecommendations ?: return@update state
                     val updatedRecs = relAndRecs.recommendations.map { node ->
                         if (node.mediaRecommended.id == recommendationId) {
-                            node.copy(mediaRecommended = node.mediaRecommended.copy(
-                                    rating = result.data.SaveRecommendation?.rating,
-                                    userRating = newRating
-                                )
-                            )
+node.copy(mediaRecommended = node.mediaRecommended.copy(
+        rating = result.data.SaveRecommendation?.rating ?: node.mediaRecommended.rating,
+        userRating = result.data.SaveRecommendation?.userRating ?: newRating
+    )
+)
                         } else node
                     }
                     state.copy(relationsAndRecommendations = relAndRecs.copy(recommendations = updatedRecs))

--- a/feature/mediadetails/src/main/java/com/axiel7/anihyou/feature/mediadetails/MediaDetailsViewModel.kt
+++ b/feature/mediadetails/src/main/java/com/axiel7/anihyou/feature/mediadetails/MediaDetailsViewModel.kt
@@ -12,6 +12,7 @@ import com.axiel7.anihyou.core.network.MediaDetailsQuery
 import com.axiel7.anihyou.core.network.fragment.BasicMediaListEntry
 import com.axiel7.anihyou.core.network.fragment.MediaCharacter
 import com.axiel7.anihyou.core.network.type.MediaType
+import com.axiel7.anihyou.core.network.type.RecommendationRating
 import com.axiel7.anihyou.core.ui.common.navigation.Routes
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.launchIn
@@ -207,6 +208,47 @@ class MediaDetailsViewModel(
 
     override fun hideVoiceActorSheet() {
         mutableUiState.update { it.copy(showVoiceActorsSheet = false) }
+    }
+
+    override fun onVoteClick(recommendedMediaId: Int, recommendationId: Int, rating: RecommendationRating) {
+        if (!arguments.isLoggedIn) { // look if the user is logged in, if not show an error to log in
+            mutableUiState.update { it.copy(error = "Please login to use this feature") } // show a popup to login
+            return
+        }
+
+        val recommendations = mutableUiState.value.relationsAndRecommendations?.recommendations
+        val targetNode = recommendations?.find { it.mediaRecommended.id == recommendationId } ?: return
+
+        val previousUserRating = targetNode.mediaRecommended.userRating
+        val newRating = if (previousUserRating == rating) RecommendationRating.NO_RATING else rating // if the new rating is the same as the old one remove the rating
+
+        mediaRepository.saveRecommendation(
+            mediaId = arguments.id, // base media id
+            mediaRecommendationId = recommendedMediaId, // id of the media which gets recommended
+            rating = newRating
+        ).onEach { result ->
+            // on success
+            if (result is DataResult.Success) {
+                mutableUiState.update { state ->
+                    val relAndRecs = state.relationsAndRecommendations ?: return@update state
+                    val updatedRecs = relAndRecs.recommendations.map { node ->
+                        if (node.mediaRecommended.id == recommendationId) {
+                            node.copy(mediaRecommended = node.mediaRecommended.copy(
+                                    rating = result.data.SaveRecommendation?.rating,
+                                    userRating = newRating
+                                )
+                            )
+                        } else node
+                    }
+                    state.copy(relationsAndRecommendations = relAndRecs.copy(recommendations = updatedRecs))
+                }
+            }
+            if (result is DataResult.Error) {
+                mutableUiState.update { state ->
+                    return@update state.copy(error = result.message)
+                }
+            }
+        }.launchIn(viewModelScope)
     }
 
     private suspend fun fetchAnimeThemes(idMal: Int) {

--- a/feature/mediadetails/src/main/java/com/axiel7/anihyou/feature/mediadetails/composables/MediaRelationsView.kt
+++ b/feature/mediadetails/src/main/java/com/axiel7/anihyou/feature/mediadetails/composables/MediaRelationsView.kt
@@ -16,9 +16,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.axiel7.anihyou.core.common.utils.NumberUtils.format
 import com.axiel7.anihyou.core.model.media.localized
+import com.axiel7.anihyou.core.network.type.RecommendationRating
 import com.axiel7.anihyou.core.resources.R
 import com.axiel7.anihyou.core.ui.composables.InfoTitle
-import com.axiel7.anihyou.core.ui.composables.TextIconHorizontal
+import com.axiel7.anihyou.core.ui.composables.UpvoteDownvoteHorizontalText
 import com.axiel7.anihyou.core.ui.composables.list.DiscoverLazyRow
 import com.axiel7.anihyou.core.ui.composables.media.MediaItemVertical
 import com.axiel7.anihyou.core.ui.composables.media.MediaItemVerticalPlaceholder
@@ -30,6 +31,7 @@ fun MediaRelationsView(
     uiState: MediaDetailsUiState,
     fetchData: () -> Unit,
     navigateToDetails: (Int) -> Unit,
+    onVoteClick: (Int, Int, RecommendationRating) -> Unit = { _, _, _ -> },
 ) {
     val isLoading = uiState.relationsAndRecommendations == null
 
@@ -89,26 +91,39 @@ fun MediaRelationsView(
                     count = mediaRecommendations.size,
                     contentType = { it }
                 ) {
+
                     val item = mediaRecommendations[it]
+                    val userRecLike = item.mediaRecommended.userRating
+                    val id: Int? = item.mediaRecommended.mediaRecommendation?.id
+                        ?: item.mediaRecommended.mediaRecommendation?.basicMediaDetails?.id // id of the media which gets recommended
+                    val recId: Int = item.mediaRecommended.id // id of the actual recommendation
+
+
                     MediaItemVertical(
                         title = item.mediaRecommended.mediaRecommendation?.basicMediaDetails
                             ?.title?.userPreferred.orEmpty(),
                         imageUrl = item.mediaRecommended.mediaRecommendation?.coverImage?.large,
                         modifier = Modifier.padding(horizontal = 8.dp),
                         subtitle = {
-                            TextIconHorizontal(
-                                text = item.mediaRecommended.rating?.format().orEmpty(),
-                                icon = R.drawable.thumbs_up_down_20,
-                                color = MaterialTheme.colorScheme.outline,
-                                fontSize = 14.sp
+                            UpvoteDownvoteHorizontalText(
+                                ratingText = item.mediaRecommended.rating?.format().orEmpty(),
+                                isUpvoted = userRecLike == RecommendationRating.RATE_UP,
+                                isDownvoted = userRecLike == RecommendationRating.RATE_DOWN,
+                                onUpvoteClick = {
+                                    if (id != null) onVoteClick(id, recId, RecommendationRating.RATE_UP)
+                                },
+                                onDownvoteClick = {
+                                    if (id != null) onVoteClick(id, recId, RecommendationRating.RATE_DOWN)
+                                },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = 4.dp)
                             )
                         },
                         status = item.mediaRecommended.mediaRecommendation?.mediaListEntry
                             ?.basicMediaListEntry?.status,
                         minLines = 2,
                         onClick = {
-                            val id = item.mediaRecommended.mediaRecommendation?.id
-                                ?: item.mediaRecommended.mediaRecommendation?.basicMediaDetails?.id
                             id?.let(navigateToDetails)
                         }
                     )


### PR DESCRIPTION
# Pull Request 

## Summary 
Replaced the `TextIconHorizontal` in `MediaRelationsView` with the new `UpvoteDownvoteHorizontalText` to actually be able to like/dislike the media. 

### Preview: 
<img width="540" height="409" alt="Screenshot_2026-07-25-10-07-28-38_7468087053831dbf4a2a86bd4eb5f329" src="https://github.com/user-attachments/assets/66f35e0b-c709-4313-8a54-c19d52d54ce7" />

## Changes 
- Added two separate thumbs up and down to vote the recommended media 
- In the 'onVoteClick` it checks if logged in and shows an error if not 
- When the API call is finished it updates the UI state 

## Related Issue
- Related to Issue #188 

## Notes 
- The error showing to login is not translated and will always show "Please login to use this feature".